### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,16 @@ Go to: http://localhost:8000/n2b/FACEBOOK_ID/FACEBOOK_TOKEN
 
 You will see all of your Facebook friend on Tinder
 
-## Contributing
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
-
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/nicolas2bert/tinder-stalker/tags). 
 
 ## Authors
 
 * **Nicolas2Bert** - *Initial work* - [PurpleBooth](https://github.com/PurpleBooth)
 
-See also the list of [contributors](https://github.com/your/project/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/nicolas2bert/tinder-stalker/contributors) who participated in this project.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License.


### PR DESCRIPTION
Remove invalid CONTRIBUTING.md section, LICENSE.md link, and add valid hyperlinks to contributors and tags.